### PR TITLE
QuickJS function proxy fails when there are no arguments

### DIFF
--- a/quickjs/src/main/java/com/squareup/quickjs/QuickJs.java
+++ b/quickjs/src/main/java/com/squareup/quickjs/QuickJs.java
@@ -133,12 +133,18 @@ public final class QuickJs implements Closeable {
         new InvocationHandler() {
           @Override
           public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+
+            Object[] argsToSend = args;
+            if (argsToSend == null) {
+              argsToSend = new Object[0];
+            }
+
             // If the method is a method from Object then defer to normal invocation.
             if (method.getDeclaringClass() == Object.class) {
-              return method.invoke(this, args);
+              return method.invoke(this, argsToSend);
             }
             synchronized (quickJs) {
-              return call(quickJs.context, instance, method, args);
+              return call(quickJs.context, instance, method, argsToSend);
             }
           }
 


### PR DESCRIPTION
If I make the following interface:

```
interface What {
    fun value(): Int
}
```
then try create a proxy to a JS object that matches the interface:

```
val context = QuickJs.create()
context.evaluate("var test_value = {value: function() {return 10 }};")
val gotInstance = context.get("test_value",What::class.java)
val gotValue = gotInstance.value()
```

That last line fails, because the args array is null. However the interface instead looks like:

```
interface What {
    fun value(i:Int): Int
}
```

and I run `gotInstance.value(10)` it works fine, because an array has been passed.

I've attached a pull request that fixes the issue by creating an issue if there isn't one. There's almost definitely a better way to do this, but the C++ code is a little out of my comfort zone so I've left it like this for now.